### PR TITLE
add extensionKind

### DIFF
--- a/package.json
+++ b/package.json
@@ -259,5 +259,9 @@
     "eventsource-parser": "^1.1.1",
     "node-fetch": "^3.3.2",
     "openai": "^3.1.0"
-  }
+  },
+  "extensionKind": [
+    "ui",
+    "workspace"
+  ]
 }


### PR DESCRIPTION
考虑到本地部署的可能性比较大，这样配置可以让默认状态下在vscode remote的窗口中也显示action bar的按钮使用